### PR TITLE
This PR addresses the issue 77 which throws an error when listening on signals.

### DIFF
--- a/event_pipeline/signal/signals.py
+++ b/event_pipeline/signal/signals.py
@@ -211,7 +211,7 @@ class SoftSignal(ObjectIdentityMixin):
 
 
 pipeline_pre_init = SoftSignal(
-    "pipeline_pre_init", provide_args=["cls", "args", "kwargs"]
+    "pipeline_pre_init", provide_args=["args", "kwargs"]
 )
 pipeline_post_init = SoftSignal("pipeline_post_init", provide_args=["pipeline"])
 


### PR DESCRIPTION
The error was actually caused by the pipeline_pre_init signal which was expecting an argument cls when used. The parameter has been removed from the signal definition and batch execution flow works fine as expected.