### PR TITLE
Issue 119 remote executors

### DIFF
--- a/tests/unittests/test_base_remote_executor.py
+++ b/tests/unittests/test_base_remote_executor.py
@@ -16,7 +16,7 @@ class TestBaseRemoteExecutor(unittest.TestCase):
     def setUp(self):
         self.executor = BaseRemoteExecutor()
 
-        patcher = patch('volnux.executors.base_remote_executor.CONF')
+        patcher = patch("volnux.executors.base_remote_executor.CONF")
         self.mock_conf = patcher.start()
         self.mock_conf.SECRET_KEY = "test_secret_key"
         self.addCleanup(patcher.stop)
@@ -61,10 +61,7 @@ class TestBaseRemoteExecutor(unittest.TestCase):
         """Test payload construction with special characters"""
         mock_message = MagicMock()
         # Including special characters and unicode
-        mock_message.dump.return_value = {
-            "task_id": "spec!@#$",
-            "data": "test_data_😊"
-        }
+        mock_message.dump.return_value = {"task_id": "spec!@#$", "data": "test_data_😊"}
 
         payload = self.executor.construct_payload(mock_message)
 

--- a/tests/unittests/test_base_remote_executor.py
+++ b/tests/unittests/test_base_remote_executor.py
@@ -1,0 +1,98 @@
+import unittest
+import sys
+import json
+import base64
+import hmac
+import hashlib
+from unittest.mock import MagicMock, patch
+from volnux.executors.base_remote_executor import BaseRemoteExecutor
+
+
+mock_options = MagicMock()
+sys.modules["volnux.parser.options"] = mock_options
+
+
+class TestBaseRemoteExecutor(unittest.TestCase):
+    def setUp(self):
+        self.executor = BaseRemoteExecutor()
+
+        patcher = patch('volnux.executors.base_remote_executor.CONF')
+        self.mock_conf = patcher.start()
+        self.mock_conf.SECRET_KEY = "test_secret_key"
+        self.addCleanup(patcher.stop)
+
+    def test_get_secret_key(self):
+        """Test retrieving secret key from configuration"""
+        from volnux.executors.base_remote_executor import get_secret_key
+
+        self.mock_conf.SECRET_KEY = "string_key"
+        self.assertEqual(get_secret_key(), b"string_key")
+
+        self.mock_conf.SECRET_KEY = b"bytes_key"
+        self.assertEqual(get_secret_key(), b"bytes_key")
+
+    def test_generate_hmac(self):
+        """Test HMAC generation"""
+        data = {"test": "data"}
+        signature, algorithm = self.executor._generate_hmac(data)
+
+        expected_bytes = json.dumps(data, sort_keys=True).encode("utf-8")
+        expected_signature = hmac.new(
+            b"test_secret_key", expected_bytes, hashlib.sha256
+        ).digest()
+        expected_b64 = base64.b64encode(expected_signature).decode("utf-8")
+
+        self.assertEqual(signature, expected_b64)
+        self.assertEqual(algorithm, "sha256")
+
+    def test_construct_payload(self):
+        """Test payload construction and HMAC generation"""
+        mock_message = MagicMock()
+        mock_message.dump.return_value = {"task_id": "123", "args": [1, 2]}
+
+        payload = self.executor.construct_payload(mock_message)
+
+        self.assertIn("_signature", payload)
+        self.assertIn("_algorithm", payload)
+        self.assertEqual(payload["task_id"], "123")
+        self.assertEqual(payload["_algorithm"], "sha256")
+
+    def test_construct_payload_special_characters(self):
+        """Test payload construction with special characters"""
+        mock_message = MagicMock()
+        # Including special characters and unicode
+        mock_message.dump.return_value = {
+            "task_id": "spec!@#$",
+            "data": "test_data_😊"
+        }
+
+        payload = self.executor.construct_payload(mock_message)
+
+        self.assertIn("_signature", payload)
+        self.assertEqual(payload["data"], "test_data_😊")
+
+        # Verify signature is generated for this specific payload
+        # Note: we need to remove signature/algo fields to verify against _generate_hmac logic locally if we wanted strict verification,
+        # but _generate_hmac is tested separately. Here we ensure it doesn't crash and returns valid structure.
+        self.assertTrue(len(payload["_signature"]) > 0)
+
+    def test_construct_payload_empty_args(self):
+        """Test payload construction with empty args"""
+        mock_message = MagicMock()
+        mock_message.dump.return_value = {}
+
+        payload = self.executor.construct_payload(mock_message)
+
+        self.assertIn("_signature", payload)
+        self.assertIn("_algorithm", payload)
+
+    def test_construct_payload_unserializable(self):
+        """Test payload construction with unserializable data"""
+        mock_message = MagicMock()
+        # Sets are not JSON serializable by default
+        mock_message.dump.return_value = {"invalid": {1, 2, 3}}
+
+        with self.assertRaises(ValueError) as context:
+            self.executor.construct_payload(mock_message)
+
+        self.assertEqual(str(context.exception), "Payload is not serializable")

--- a/tests/unittests/test_base_remote_executor.py
+++ b/tests/unittests/test_base_remote_executor.py
@@ -4,11 +4,6 @@ from unittest.mock import MagicMock, patch
 from volnux.executors.base_remote_executor import BaseRemoteExecutor
 
 
-# Mocking volnux.parser.options to avoid ImportError/TypeError in environment
-mock_options = MagicMock()
-sys.modules["volnux.parser.options"] = mock_options
-
-
 class TestBaseRemoteExecutor(unittest.TestCase):
     def setUp(self):
         self.executor = BaseRemoteExecutor()

--- a/tests/unittests/test_base_remote_executor.py
+++ b/tests/unittests/test_base_remote_executor.py
@@ -1,13 +1,10 @@
-import unittest
 import sys
-import json
-import base64
-import hmac
-import hashlib
+import unittest
 from unittest.mock import MagicMock, patch
 from volnux.executors.base_remote_executor import BaseRemoteExecutor
 
 
+# Mocking volnux.parser.options to avoid ImportError/TypeError in environment
 mock_options = MagicMock()
 sys.modules["volnux.parser.options"] = mock_options
 
@@ -15,81 +12,137 @@ sys.modules["volnux.parser.options"] = mock_options
 class TestBaseRemoteExecutor(unittest.TestCase):
     def setUp(self):
         self.executor = BaseRemoteExecutor()
-
+        # Mocking configuration
         patcher = patch("volnux.executors.base_remote_executor.CONF")
         self.mock_conf = patcher.start()
         self.mock_conf.SECRET_KEY = "test_secret_key"
+        self.mock_conf.REMOTE_EVENT_TIMEOUT = 30
         self.addCleanup(patcher.stop)
 
     def test_get_secret_key(self):
         """Test retrieving secret key from configuration"""
         from volnux.executors.base_remote_executor import get_secret_key
 
+        # Test string key
         self.mock_conf.SECRET_KEY = "string_key"
         self.assertEqual(get_secret_key(), b"string_key")
 
+        # Test bytes key
         self.mock_conf.SECRET_KEY = b"bytes_key"
         self.assertEqual(get_secret_key(), b"bytes_key")
 
-    def test_generate_hmac(self):
-        """Test HMAC generation"""
-        data = {"test": "data"}
-        signature, algorithm = self.executor._generate_hmac(data)
+    @patch("volnux.utils.generate_hmac")
+    @patch("socket.gethostname")
+    def test_construct_payload(self, mock_hostname, mock_generate_hmac):
+        """Test payload construction with new signature and return type"""
+        mock_hostname.return_value = "test_host"
+        mock_generate_hmac.return_value = ("test_hmac", "sha256")
 
-        expected_bytes = json.dumps(data, sort_keys=True).encode("utf-8")
-        expected_signature = hmac.new(
-            b"test_secret_key", expected_bytes, hashlib.sha256
-        ).digest()
-        expected_b64 = base64.b64encode(expected_signature).decode("utf-8")
+        event_name = "test_event"
+        args = {"arg1": 1, "arg2": "value"}
 
-        self.assertEqual(signature, expected_b64)
-        self.assertEqual(algorithm, "sha256")
+        # construct_payload now returns a Payload object
+        payload = self.executor.construct_payload(event_name, args)
 
-    def test_construct_payload(self):
-        """Test payload construction and HMAC generation"""
-        mock_message = MagicMock()
-        mock_message.dump.return_value = {"task_id": "123", "args": [1, 2]}
+        # Verify Payload object structure/attributes
+        self.assertEqual(payload.event_name, event_name)
+        self.assertEqual(payload.args, args)
+        self.assertEqual(payload.client_id, "test_host")
+        self.assertEqual(payload.hmac, "test_hmac")
+        self.assertEqual(payload.timeout, 30)
 
-        payload = self.executor.construct_payload(mock_message)
+        # Verify generate_hmac call
+        mock_generate_hmac.assert_called_once()
+        call_args, _ = mock_generate_hmac.call_args
+        data_arg = call_args[0]
+        secret_key_arg = call_args[1]
 
-        self.assertIn("_signature", payload)
-        self.assertIn("_algorithm", payload)
-        self.assertEqual(payload["task_id"], "123")
-        self.assertEqual(payload["_algorithm"], "sha256")
+        self.assertEqual(data_arg["event_name"], event_name)
+        self.assertEqual(data_arg["args"], args)
+        self.assertEqual(data_arg["type"], "submission_event")
+        self.assertEqual(secret_key_arg, b"test_secret_key")
 
-    def test_construct_payload_special_characters(self):
-        """Test payload construction with special characters"""
-        mock_message = MagicMock()
-        # Including special characters and unicode
-        mock_message.dump.return_value = {"task_id": "spec!@#$", "data": "test_data_😊"}
+    @patch("volnux.utils.generate_hmac")
+    @patch("socket.gethostname")
+    def test_construct_payload_edge_cases(self, mock_hostname, mock_generate_hmac):
+        """Test payload construction with edge cases like empty args or special chars"""
+        mock_hostname.return_value = "test_host"
+        mock_generate_hmac.return_value = ("test_hmac", "sha256")
 
-        payload = self.executor.construct_payload(mock_message)
+        # Special characters
+        event_name = "special!@#"
+        args = {"key": "val &*("}
 
-        self.assertIn("_signature", payload)
-        self.assertEqual(payload["data"], "test_data_😊")
+        payload = self.executor.construct_payload(event_name, args)
+        self.assertEqual(payload.event_name, event_name)
+        self.assertEqual(payload.args, args)
 
-        # Verify signature is generated for this specific payload
-        # Note: we need to remove signature/algo fields to verify against _generate_hmac logic locally if we wanted strict verification,
-        # but _generate_hmac is tested separately. Here we ensure it doesn't crash and returns valid structure.
-        self.assertTrue(len(payload["_signature"]) > 0)
+        # Empty args
+        payload_empty = self.executor.construct_payload("empty_event", {})
+        self.assertEqual(payload_empty.args, {})
 
-    def test_construct_payload_empty_args(self):
-        """Test payload construction with empty args"""
-        mock_message = MagicMock()
-        mock_message.dump.return_value = {}
+    @patch("volnux.utils.verify_hmac")
+    def test_parse_response_success(self, mock_verify_hmac):
+        """Test successful response parsing"""
+        from volnux.types import TaskExecutionSuccessResponse
 
-        payload = self.executor.construct_payload(mock_message)
+        mock_verify_hmac.return_value = True
 
-        self.assertIn("_signature", payload)
-        self.assertIn("_algorithm", payload)
+        response = TaskExecutionSuccessResponse(
+            correlation_id="123",
+            result={"output": "success"},
+            completed_at=1234567890.0,
+            hmac="valid_hmac",
+        )
 
-    def test_construct_payload_unserializable(self):
-        """Test payload construction with unserializable data"""
-        mock_message = MagicMock()
-        # Sets are not JSON serializable by default
-        mock_message.dump.return_value = {"invalid": {1, 2, 3}}
+        result = self.executor.parse_task_execution_response(response)
 
-        with self.assertRaises(ValueError) as context:
-            self.executor.construct_payload(mock_message)
+        self.assertEqual(result, {"output": "success"})
+        mock_verify_hmac.assert_called_once()
 
-        self.assertEqual(str(context.exception), "Payload is not serializable")
+    @patch("volnux.utils.verify_hmac")
+    def test_parse_response_invalid_hmac(self, mock_verify_hmac):
+        """Test parsing response with invalid HMAC"""
+        from volnux.types import TaskExecutionSuccessResponse
+        from volnux.exceptions import RemoteExecutionError
+
+        mock_verify_hmac.return_value = False
+
+        response = TaskExecutionSuccessResponse(
+            correlation_id="123",
+            result={"output": "success"},
+            completed_at=1234567890.0,
+            hmac="invalid_hmac",
+        )
+
+        with self.assertRaises(RemoteExecutionError) as cm:
+            self.executor.parse_task_execution_response(response)
+
+        self.assertEqual(str(cm.exception), "INVALID_HMAC")
+
+    def test_parse_response_error(self):
+        """Test parsing error response"""
+        from volnux.types import TaskExecutionErrorResponse
+        from volnux.exceptions import RemoteExecutionError
+
+        response = TaskExecutionErrorResponse(
+            correlation_id="123",
+            message="Something went wrong",
+            code="ERROR_CODE",
+            timestamp=1234567890.0,
+        )
+
+        with self.assertRaises(RemoteExecutionError) as cm:
+            self.executor.parse_task_execution_response(response)
+
+        self.assertIn("ERROR_CODE: Something went wrong", str(cm.exception))
+
+    def test_submit_not_implemented(self):
+        """Test that submit raises NotImplementedError"""
+        with self.assertRaises(NotImplementedError):
+            self.executor.submit(lambda: None)
+
+    def test_query_event_exists_not_implemented(self):
+        """Test that query_event_exists raises NotImplementedError"""
+        with self.assertRaises(NotImplementedError):
+            self.executor.query_event_exists(MagicMock())

--- a/volnux/exceptions.py
+++ b/volnux/exceptions.py
@@ -155,3 +155,7 @@ class ExecutorNotFound(IndexError):
 
 class PointyNotExecutable(Exception):
     """Exception raised when a pointy script is not executable."""
+
+class RemoteExecutionError(Exception):
+    """Exception raised when a remote execution fails."""
+    pass

--- a/volnux/executors/base_remote_executor.py
+++ b/volnux/executors/base_remote_executor.py
@@ -23,7 +23,9 @@ def get_secret_key() -> bytes:
 
 
 class BaseRemoteExecutor(Executor):
-    def _generate_hmac(self, data: typing.Dict[str, typing.Any]) -> typing.Tuple[str, str]:
+    def _generate_hmac(
+        self, data: typing.Dict[str, typing.Any]
+    ) -> typing.Tuple[str, str]:
         """Generate a signature for the payload."""
         data_bytes = json.dumps(data, sort_keys=True).encode("utf-8")
 
@@ -59,6 +61,6 @@ class BaseRemoteExecutor(Executor):
         return str(uuid.uuid4())
 
     def submit(
-            self, fn: typing.Callable, /, *args, **kwargs
+        self, fn: typing.Callable, /, *args, **kwargs
     ) -> concurrent.futures.Future:
         pass

--- a/volnux/executors/base_remote_executor.py
+++ b/volnux/executors/base_remote_executor.py
@@ -1,0 +1,64 @@
+import base64
+import concurrent
+import hashlib
+import hmac
+import json
+import typing
+import uuid
+from concurrent.futures import Executor
+
+from volnux.conf import ConfigLoader
+from volnux.executors.message import TaskMessage
+
+CONF = ConfigLoader.get_lazily_loaded_config()
+ALGORITHM = "sha256"
+
+
+def get_secret_key() -> bytes:
+    """Retrieve the secret key from configuration and ensure it is bytes."""
+    key = CONF.SECRET_KEY
+    if isinstance(key, str):
+        return key.encode("utf-8")
+    return key
+
+
+class BaseRemoteExecutor(Executor):
+    def _generate_hmac(self, data: typing.Dict[str, typing.Any]) -> typing.Tuple[str, str]:
+        """Generate a signature for the payload."""
+        data_bytes = json.dumps(data, sort_keys=True).encode("utf-8")
+
+        signature = hmac.new(
+            get_secret_key(), data_bytes, getattr(hashlib, ALGORITHM)
+        ).digest()
+
+        return base64.b64encode(signature).decode("utf-8"), ALGORITHM
+
+    def construct_payload(self, data: TaskMessage) -> typing.Dict[str, typing.Any]:
+        """Construct the payload to send to the remote manager."""
+        dict_data = data.dump(_format="dict")
+
+        if not self._is_payload_serializable(dict_data):
+            raise ValueError("Payload is not serializable")
+
+        signature, algorithm = self._generate_hmac(dict_data)
+        dict_data["_signature"] = signature
+        dict_data["_algorithm"] = algorithm
+
+        return dict_data
+
+    def _is_payload_serializable(self, payload: typing.Dict[str, typing.Any]) -> bool:
+        """Check if the payload can be serialized."""
+        try:
+            json.dumps(payload)
+        except (TypeError, OverflowError) as e:
+            return False
+        return True
+
+    def generate_correlation_id(self) -> str:
+        """Generate a unique correlation ID."""
+        return str(uuid.uuid4())
+
+    def submit(
+            self, fn: typing.Callable, /, *args, **kwargs
+    ) -> concurrent.futures.Future:
+        pass

--- a/volnux/settings.py
+++ b/volnux/settings.py
@@ -54,3 +54,5 @@ LOGGING_CONFIG = {
         },
     },
 }
+
+REMOTE_EVENT_TIMEOUT = None

--- a/volnux/types.py
+++ b/volnux/types.py
@@ -1,0 +1,46 @@
+import typing
+
+from pydantic_mini import BaseModel
+
+
+class Payload(BaseModel):
+    type: str
+    correlation_id: str
+    event_name: str
+    args: dict
+    client_id: str
+    timeout: typing.Optional[int]
+    timestamp: float
+    hmac: str
+
+
+class QueryEventPayload(BaseModel):
+    type: str = "event_query"
+    event_name: str
+    client_id: str
+
+
+class QueryEventResponse(BaseModel):
+    type: str = "event_availability"
+    event_name: str
+    available: bool
+    message: str
+    metadata: dict
+
+
+class TaskExecutionErrorResponse(BaseModel):
+    type: str = "error"
+    correlation_id: str
+    status: str = "error"
+    message: str
+    code: str
+    timestamp: float
+
+
+class TaskExecutionSuccessResponse(BaseModel):
+    type: str = "task_response"
+    correlation_id: str
+    status: str = "success"
+    result: dict
+    completed_at: float
+    hmac: str


### PR DESCRIPTION
This PR addresses the issue 119 base remote executor. It adds a base class with methods that constructs a payload, generate a hmac and adds it to the payload.