### PR TITLE
Extending parser to support list and map values

### DIFF
--- a/volnux/parser/ast.py
+++ b/volnux/parser/ast.py
@@ -257,6 +257,21 @@ class LiteralNode(ASTNode):
     def accept(self, visitor: "ASTVisitor"):
         return visitor.visit_literal(self)
 
+@dataclass
+class ListNode(ASTNode):
+    __slots__ = ("value",)
+    value: typing.List[typing.Any]
+
+    def accept(self, visitor: "ASTVisitor"):
+        return visitor.visit_list(self)
+
+@dataclass
+class MapNode(ASTNode):
+    __slots__ = ("value",)
+    value: typing.Dict[str, typing.Any]
+
+    def accept(self, visitor: "ASTVisitor"):
+        return visitor.visit_map(self)
 
 @dataclass
 class ExpressionGroupingNode(ASTNode):

--- a/volnux/parser/grammar.py
+++ b/volnux/parser/grammar.py
@@ -214,7 +214,7 @@ def p_map_entries(p):
     """
     map_entries : empty
                 | map_entry
-                | map_entries COMMA map_entry
+                | map_entries SEPARATOR map_entry
     """
     if p[1] is None:
         p[0] = {}
@@ -239,7 +239,7 @@ def p_list(p):
 def p_list_elements(p):
     """
     list_elements : value
-                  | list_elements COMMA value
+                  | list_elements SEPARATOR value
                   | empty
     """
     is_empty = p[1] is None

--- a/volnux/parser/grammar.py
+++ b/volnux/parser/grammar.py
@@ -21,6 +21,8 @@ from .ast import (
     EnvironmentVariableAccessNode,
     DirectiveNode,
     MetaEventNode,
+    ListNode,
+    MapNode,
 )
 from .dag_visitor import CycleDetectionVisitor, DAGValidationError, format_cycle_error
 
@@ -196,10 +198,65 @@ def p_value(p):
     """
     value : scalar_value
             | variable_reference
+            | list
+            | map
             | null_value
     """
     p[0] = p[1]
 
+def p_map(p):
+    """
+    map : LCURLY_BRACKET map_entries RCURLY_BRACKET
+    """
+    p[0] = MapNode(p[2])
+
+def p_map_entries(p):
+    """
+    map_entries : empty
+                | map_entry
+                | map_entries COMMA map_entry
+    """
+    if p[1] is None:
+        p[0] = {}
+    elif len(p) == 2:
+        p[0] = p[1]
+    elif len(p) == 4:
+        p[1].update(p[3])
+        p[0] = p[1]
+
+def p_map_entry(p):
+    """
+    map_entry : STRING_LITERAL COLON value
+    """
+    p[0] = {p[1]: p[3]}
+
+def p_list(p):
+    """
+    list : LBRACKET list_elements RBRACKET
+    """
+    p[0] = ListNode(p[2])
+
+def p_list_elements(p):
+    """
+    list_elements : value
+                  | list_elements COMMA value
+                  | empty
+    """
+    is_empty = p[1] is None
+    is_single_item = len(p) == 2
+    is_multi_items = len(p) == 4
+
+    if is_empty:
+        p[0] = []
+    elif is_single_item:
+        p[0] = [p[1]]
+    elif is_multi_items:
+        p[0] = p[1] + [p[3]]
+
+
+def p_empty(p):
+    'empty :'
+    pass
 
 def p_scalar_value(p):
     """

--- a/volnux/parser/lexer.py
+++ b/volnux/parser/lexer.py
@@ -61,6 +61,7 @@ class PointyLexer(object):
             "INT",
             "FLOAT",
             "BOOLEAN",
+            "COMMA",
             # Operators
             "NULLCOALESCE",  # ??
             "EQ",  # ==
@@ -94,6 +95,7 @@ class PointyLexer(object):
     t_DOUBLE_COLON = r"::"
     t_LANGLE = r"<"
     t_RANGLE = r">"
+    t_COMMA = r","
     t_ignore_COMMENT = r"\#.*"
 
     def t_LE(self, t):

--- a/volnux/parser/lexer.py
+++ b/volnux/parser/lexer.py
@@ -61,7 +61,6 @@ class PointyLexer(object):
             "INT",
             "FLOAT",
             "BOOLEAN",
-            "COMMA",
             # Operators
             "NULLCOALESCE",  # ??
             "EQ",  # ==
@@ -95,7 +94,6 @@ class PointyLexer(object):
     t_DOUBLE_COLON = r"::"
     t_LANGLE = r"<"
     t_RANGLE = r">"
-    t_COMMA = r","
     t_ignore_COMMENT = r"\#.*"
 
     def t_LE(self, t):

--- a/volnux/parser/visitor.py
+++ b/volnux/parser/visitor.py
@@ -16,6 +16,8 @@ if typing.TYPE_CHECKING:
         VariableAccessNode,
         MetaEventNode,
         EnvironmentVariableAccessNode,
+        ListNode,
+        MapNode,
     )
 
 
@@ -70,4 +72,12 @@ class ASTVisitorInterface(ABC):
 
     @abstractmethod
     def visit_meta_event(self, node: "MetaEventNode"):
+        pass
+
+    @abstractmethod
+    def visit_list(self, node: "ListNode"):
+        pass
+
+    @abstractmethod
+    def visit_map(self, node: "MapNode"):
         pass


### PR DESCRIPTION
proposed implementation for issue #128 

This PR provides an implementation for list and map values in the parser. It first extends the grammer for `p_value` to include list and map like so:

```
def p_value(p):
    """
    value : scalar_value
            | variable_reference
            | list
            | map
            | null_value
    """
```

This implements the `p` functions for list and map using the following grammar:

```
  map : LCURLY_BRACKET map_entries RCURLY_BRACKET
  map_entries : empty
              | map_entry
              | map_entries COMMA map_entry
  map_entry : STRING_LITERAL COLON value
```
```
list : LBRACKET list_elements RBRACKET
list_elements : empty
              | value
              | list_elements COMMA value
```
```
'empty :'
```

The implementation further creates a `ListNode` and 'MapNode' AST types and provides their corresponding stubs in the visitor class.
